### PR TITLE
Custom splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ scene.add(mesh);
 	
 	- `settings.mode` — Defines a split scheme (how large frustum is splitted into smaller ones). Can be `uniform` (linear), `logarithmic`, `practical` or `custom`. For most cases `practical` may be the best choice. Equations used for each scheme can be found in [*GPU Gems 3. Chapter 10*](https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch10.html). If mode is set to `custom`, you'll need to define your own `customSplitsCallback`. Optional.
 
-    - `settings.customSplitsCallback` — A callback to compute custom cascade splits when mode is set to `custom`. Callback should accept three number parameters: cascadeAmount, nearDistance, farDistance and return an array of split distances ranging from 0 to 1, where 0 is equal to nearDistance and 1 is equal to farDistance. Check out the official modes in CSM.js to learn how they work.
+    - `settings.customSplitsCallback` — A callback to compute custom cascade splits when mode is set to `custom`. Callback should accept three number parameters: `cascadeAmount`, `nearDistance`, `farDistance` and return an array of split distances ranging from 0 to 1, where 0 is equal to `nearDistance` and 1 is equal to `farDistance`. Check out the official modes in CSM.js to learn how they work.
 	
 	- `settings.shadowMapSize` — Resolution of shadow maps (one per cascade). Optional.
 	

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ scene.add(mesh);
 	
 	- `settings.mode` — Defines a split scheme (how large frustum is splitted into smaller ones). Can be `uniform` (linear), `logarithmic`, `practical` or `custom`. For most cases `practical` may be the best choice. Equations used for each scheme can be found in [*GPU Gems 3. Chapter 10*](https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch10.html). If mode is set to `custom`, you'll need to define your own `customSplitsCallback`. Optional.
 
-    - `settings.customSplitsCallback` - A callback to compute custom cascade splits when mode is set to `custom`. Callback should accept three number parameters: cascadeAmount, nearDistance, farDistance and return an array of split distances ranging from 0 to 1, where 0 is equal to nearDistance and 1 is equal to farDistance. Check out the official modes in CSM.js to learn how they work.
+    - `settings.customSplitsCallback` — A callback to compute custom cascade splits when mode is set to `custom`. Callback should accept three number parameters: cascadeAmount, nearDistance, farDistance and return an array of split distances ranging from 0 to 1, where 0 is equal to nearDistance and 1 is equal to farDistance. Check out the official modes in CSM.js to learn how they work.
 	
 	- `settings.shadowMapSize` — Resolution of shadow maps (one per cascade). Optional.
 	

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ scene.add(mesh);
 	
 	- `settings.cascades` — Number of shadow cascades. Optional.
 	
-	- `settings.mode` — Defines a split scheme (how large frustum is splitted into smaller ones). Can be `uniform` (linear), `logarithmic` or `practical`. For most cases `practical` may be the best choice. Equations used for each scheme can be found in [*GPU Gems 3. Chapter 10*](https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch10.html). Optional.
+	- `settings.mode` — Defines a split scheme (how large frustum is splitted into smaller ones). Can be `uniform` (linear), `logarithmic`, `practical` or `custom`. For most cases `practical` may be the best choice. Equations used for each scheme can be found in [*GPU Gems 3. Chapter 10*](https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch10.html). If mode is set to `custom`, you'll need to define your own `customSplitsCallback`. Optional.
+
+    - `settings.customSplitsCallback` - A callback to compute custom cascade splits when mode is set to `custom`. Callback should accept three number parameters: cascadeAmount, nearDistance, farDistance and return an array of split distances ranging from 0 to 1, where 0 is equal to nearDistance and 1 is equal to farDistance. Check out the official modes in CSM.js to learn how they work.
 	
 	- `settings.shadowMapSize` — Resolution of shadow maps (one per cascade). Optional.
 	

--- a/src/CSM.js
+++ b/src/CSM.js
@@ -21,8 +21,8 @@ export default class CSM {
 		this.lightIntensity = data.lightIntensity || 1;
 		this.lightNear = data.lightNear || 1;
 		this.lightFar = data.lightFar || 2000;
-        this.lightMargin = data.lightMargin || 200;
-        this.customSplitsCallback = data.customSplitsCallback || undefined;
+		this.lightMargin = data.lightMargin || 200;
+		this.customSplitsCallback = data.customSplitsCallback;
 
 		this.lights = [];
 		this.materials = [];
@@ -77,11 +77,11 @@ export default class CSM {
 				break;
 			case 'practical':
 				this.breaks = practicalSplit(this.cascades, this.near, this.far, 0.5);
-                break;
-            case 'custom':
-                if (this.customSplitsCallback === undefined) console.error('CSM: Custom split scheme callback not defined.');
-                this.breaks = this.customSplitsCallback(this.cascades, this.near, this.far);
-                break;
+				break;
+			case 'custom':
+				if(this.customSplitsCallback === undefined) console.error('CSM: Custom split scheme callback not defined.');
+				this.breaks = this.customSplitsCallback(this.cascades, this.near, this.far);
+				break;
 		}
 		
 		function uniformSplit(amount, near, far) {

--- a/src/CSM.js
+++ b/src/CSM.js
@@ -21,7 +21,8 @@ export default class CSM {
 		this.lightIntensity = data.lightIntensity || 1;
 		this.lightNear = data.lightNear || 1;
 		this.lightFar = data.lightFar || 2000;
-		this.lightMargin = data.lightMargin || 200;
+        this.lightMargin = data.lightMargin || 200;
+        this.customSplitsCallback = data.customSplitsCallback || undefined;
 
 		this.lights = [];
 		this.materials = [];
@@ -76,7 +77,11 @@ export default class CSM {
 				break;
 			case 'practical':
 				this.breaks = practicalSplit(this.cascades, this.near, this.far, 0.5);
-				break;
+                break;
+            case 'custom':
+                if (this.customSplitsCallback === undefined) console.error('CSM: Custom split scheme callback not defined.');
+                this.breaks = this.customSplitsCallback(this.cascades, this.near, this.far);
+                break;
 		}
 		
 		function uniformSplit(amount, near, far) {


### PR DESCRIPTION
I tried all three modes, but none of them worked well with my setup.
The breaks I found work best for me are:
`[ (1/3)^3, (1/3)^2, (1/3)^1, (1/3)^0 ]`

It's probably just highly dependent on the near / far distances, and general scale of my scene right?

I think an option to define a custom splits should be there as a last resort option when none of the previous modes work with your setup. But I'm the only person using this right now, so it's up to you if you want to accept this.

What do you think? 