### PR TITLE
readme params fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ renderer.shadowMap.enabled = true;
 renderer.shadowMap.type = THREE.PCFSoftShadowMap; // or any other type of shadowmap
 	
 let csm = new THREE.CSM({
-	far: camera.far,
+	maxFar: camera.far,
 	cascades: 4,
 	shadowMapSize: 1024,
 	lightDirection: new THREE.Vector3(1, -1, 1).normalize(),
@@ -77,9 +77,7 @@ csm.update(camera.matrix);
 
 - `settings` — `Object` which contains all setting of CSMs.
 
-	- `settings.fov` — Frustum vertical field of view. Optional.
-	
-	- `settings.far` — Frustum far plane distance (i.e. shadows are not visible farther this distance from camera). May be smaller than `camera.far` value. Optional.
+	- `settings.maxFar` — Frustum far plane distance (i.e. shadows are not visible farther this distance from camera). May be smaller than `camera.far` value. Optional.
 	
 	- `settings.aspect` — Frustum aspect ratio. Optional.
 	
@@ -91,7 +89,7 @@ csm.update(camera.matrix);
 	
 	- `settings.mode` — Defines a split scheme (how large frustum is splitted into smaller ones). Can be `uniform` (linear), `logarithmic`, `practical` or `custom`. For most cases `practical` may be the best choice. Equations used for each scheme can be found in [*GPU Gems 3. Chapter 10*](https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch10.html). If mode is set to `custom`, you'll need to define your own `customSplitsCallback`. Optional.
 
-    - `settings.customSplitsCallback` — A callback to compute custom cascade splits when mode is set to `custom`. Callback should accept three number parameters: `cascadeAmount`, `nearDistance`, `farDistance` and return an array of split distances ranging from 0 to 1, where 0 is equal to `nearDistance` and 1 is equal to `farDistance`. Check out the official modes in CSM.js to learn how they work.
+	- `settings.customSplitsCallback` — A callback to compute custom cascade splits when mode is set to `custom`. Callback should accept three number parameters: `cascadeAmount`, `nearDistance`, `farDistance` and return an array of split distances ranging from 0 to 1, where 0 is equal to `nearDistance` and 1 is equal to `farDistance`. Check out the official modes in CSM.js to learn how they work.
 	
 	- `settings.shadowMapSize` — Resolution of shadow maps (one per cascade). Optional.
 	


### PR DESCRIPTION
- Removed the `fov` parameter, because I can't find a reference to it.
- Corrected the `far` parameter to `maxFar`.