### PR TITLE
Fix deprecated function getInverse()

### DIFF
--- a/build/three-csm.js
+++ b/build/three-csm.js
@@ -39,7 +39,9 @@
 
 			const isOrthographic = projectionMatrix.elements[ 2 * 4 + 3 ] === 0;
 
-			inverseProjectionMatrix.getInverse( projectionMatrix );
+
+			inverseProjectionMatrix.copy(projectionMatrix).invert();
+
 
 			// 3 --- 0  vertices.near/far order
 			// |     |

--- a/build/three-csm.module.js
+++ b/build/three-csm.module.js
@@ -35,7 +35,9 @@ class Frustum {
 
 		const isOrthographic = projectionMatrix.elements[ 2 * 4 + 3 ] === 0;
 
-		inverseProjectionMatrix.getInverse( projectionMatrix );
+
+		inverseProjectionMatrix.copy(projectionMatrix).invert();
+
 
 		// 3 --- 0  vertices.near/far order
 		// |     |

--- a/src/Frustum.js
+++ b/src/Frustum.js
@@ -35,7 +35,9 @@ export default class Frustum {
 
 		const isOrthographic = projectionMatrix.elements[ 2 * 4 + 3 ] === 0;
 
-		inverseProjectionMatrix.getInverse( projectionMatrix );
+
+		inverseProjectionMatrix.copy(projectionMatrix).invert();
+
 
 		// 3 --- 0  vertices.near/far order
 		// |     |


### PR DESCRIPTION
Fixed to work without warning in latest THREE.js build (r128)