### PR TITLE
Minor bugfixes: add lightColor, allow non-CSM light sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ csm.update(camera.matrix);
 	- `settings.shadowBias` — Serves the same purpose as [THREE.LightShadow.bias](https://threejs.org/docs/#api/en/lights/shadows/LightShadow.bias), but most likely you will need to use much smaller values. Optional.
 	
 	- `settings.lightIntensity` — Same as [THREE.DirectionalLight.intensity](https://threejs.org/docs/#api/en/lights/DirectionalLight). Optional.
+
+	- `settings.lightColor` — Same as [THREE.DirectionalLight.color](https://threejs.org/docs/#api/en/lights/DirectionalLight). Optional.
 	
 	- `settings.lightDirection` — Normalized `THREE.Vector3()`. Optional.
 	

--- a/src/CSM.ts
+++ b/src/CSM.ts
@@ -10,7 +10,8 @@ import {
 	Material,
 	Shader,
 	PerspectiveCamera,
-	OrthographicCamera
+	OrthographicCamera,
+	Color
 } from 'three';
 import CSMShader from './CSMShader';
 import CSMHelper from './CSMHelper';
@@ -76,6 +77,7 @@ export interface CSMParams {
 	shadowBias?: number;
 	lightDirection?: Vector3;
 	lightIntensity?: number;
+	lightColor?: Color;
 	lightNear?: number;
 	lightFar?: number;
 	lightMargin?: number;
@@ -93,6 +95,7 @@ class CSM {
 	public shadowBias: number;
 	public lightDirection: Vector3;
 	public lightIntensity: number;
+	public lightColor: Color;
 	public lightNear: number;
 	public lightFar: number;
 	public lightMargin: number;
@@ -115,6 +118,7 @@ class CSM {
 		this.shadowBias = data.shadowBias || 0;
 		this.lightDirection = data.lightDirection || new Vector3( 1, - 1, 1 ).normalize();
 		this.lightIntensity = data.lightIntensity || 1;
+		this.lightColor =  data.lightColor || 0xffffff;
 		this.lightNear = data.lightNear || 1;
 		this.lightFar = data.lightFar || 2000;
 		this.lightMargin = data.lightMargin || 200;
@@ -130,7 +134,7 @@ class CSM {
 
 		for ( let i = 0; i < this.cascades; i ++ ) {
 
-			const light = new DirectionalLight( 0xffffff, this.lightIntensity );
+			const light = new DirectionalLight( this.lightColor, this.lightIntensity );
 			light.castShadow = true;
 			light.shadow.mapSize.width = this.shadowMapSize;
 			light.shadow.mapSize.height = this.shadowMapSize;
@@ -138,9 +142,19 @@ class CSM {
 			light.shadow.camera.near = this.lightNear;
 			light.shadow.camera.far = this.lightFar;
 
-			this.parent.add( light );
 			this.parent.add( light.target );
 			this.lights.push( light );
+
+		}
+
+		// NOTE: Prepend lights to the parent as we assume CSM shadows come from first light sources in the world
+
+		for ( let i = this.lights.length - 1; i >= 0; i-- ) {
+
+			const light = this.lights[i];
+
+			light.parent = this.parent;
+			this.parent.children.unshift(light);
 
 		}
 
@@ -275,8 +289,8 @@ class CSM {
 
 	private injectInclude() {
 
-		ShaderChunk.lights_fragment_begin = CSMShader.lights_fragment_begin;
-		ShaderChunk.lights_pars_begin = CSMShader.lights_pars_begin;
+		ShaderChunk.lights_fragment_begin = CSMShader.lights_fragment_begin(this);
+		ShaderChunk.lights_pars_begin = CSMShader.lights_pars_begin(this);
 
 	}
 

--- a/src/CSM.ts
+++ b/src/CSM.ts
@@ -118,7 +118,7 @@ class CSM {
 		this.shadowBias = data.shadowBias || 0;
 		this.lightDirection = data.lightDirection || new Vector3( 1, - 1, 1 ).normalize();
 		this.lightIntensity = data.lightIntensity || 1;
-		this.lightColor =  data.lightColor || 0xffffff;
+		this.lightColor = data.lightColor || new Color( 0xffffff );
 		this.lightNear = data.lightNear || 1;
 		this.lightFar = data.lightFar || 2000;
 		this.lightMargin = data.lightMargin || 200;
@@ -149,12 +149,12 @@ class CSM {
 
 		// NOTE: Prepend lights to the parent as we assume CSM shadows come from first light sources in the world
 
-		for ( let i = this.lights.length - 1; i >= 0; i-- ) {
+		for ( let i = this.lights.length - 1; i >= 0; i -- ) {
 
-			const light = this.lights[i];
+			const light = this.lights[ i ];
 
 			light.parent = this.parent;
-			this.parent.children.unshift(light);
+			this.parent.children.unshift( light );
 
 		}
 
@@ -289,8 +289,8 @@ class CSM {
 
 	private injectInclude() {
 
-		ShaderChunk.lights_fragment_begin = CSMShader.lights_fragment_begin(this);
-		ShaderChunk.lights_pars_begin = CSMShader.lights_pars_begin(this);
+		ShaderChunk.lights_fragment_begin = CSMShader.lights_fragment_begin( this );
+		ShaderChunk.lights_pars_begin = CSMShader.lights_pars_begin();
 
 	}
 

--- a/src/CSMShader.ts
+++ b/src/CSMShader.ts
@@ -2,7 +2,7 @@ import { ShaderChunk } from 'three';
 import CSM from './CSM';
 
 const CSMShader = {
-	lights_fragment_begin: (csm: CSM) => /* glsl */`
+	lights_fragment_begin: ( csm: CSM ) => /* glsl */`
 GeometricContext geometry;
 
 geometry.position = - vViewPosition;
@@ -272,7 +272,7 @@ IncidentLight directLight;
 
 #endif
 `,
-	lights_pars_begin: (csm: CSM) => /* glsl */`
+	lights_pars_begin: () => /* glsl */`
 #if defined( USE_CSM ) && defined( CSM_CASCADES )
 uniform vec2 CSM_cascades[CSM_CASCADES];
 uniform float cameraNear;

--- a/src/CSMShader.ts
+++ b/src/CSMShader.ts
@@ -1,7 +1,8 @@
 import { ShaderChunk } from 'three';
+import CSM from './CSM';
 
 const CSMShader = {
-	lights_fragment_begin: /* glsl */`
+	lights_fragment_begin: (csm: CSM) => /* glsl */`
 GeometricContext geometry;
 
 geometry.position = - vViewPosition;
@@ -93,36 +94,53 @@ IncidentLight directLight;
 	  	#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 			// NOTE: Depth gets larger away from the camera.
 			// cascade.x is closer, cascade.y is further
-			cascade = CSM_cascades[ i ];
-			cascadeCenter = ( cascade.x + cascade.y ) / 2.0;
-			closestEdge = linearDepth < cascadeCenter ? cascade.x : cascade.y;
-			margin = 0.25 * pow( closestEdge, 2.0 );
-			csmx = cascade.x - margin / 2.0;
-			csmy = cascade.y + margin / 2.0;
-			if( linearDepth >= csmx && ( linearDepth < csmy || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 ) ) {
 
-				float dist = min( linearDepth - csmx, csmy - linearDepth );
-				float ratio = clamp( dist / margin, 0.0, 1.0 );
+				#if ( UNROLLED_LOOP_INDEX < ${csm.cascades} )
 
-				vec3 prevColor = directLight.color;
-				directionalLightShadow = directionalLightShadows[ i ];
-				directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+					// NOTE: Apply CSM shadows
 
-				bool shouldFadeLastCascade = UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 && linearDepth > cascadeCenter;
-				directLight.color = mix( prevColor, directLight.color, shouldFadeLastCascade ? ratio : 1.0 );
+					cascade = CSM_cascades[ i ];
+					cascadeCenter = ( cascade.x + cascade.y ) / 2.0;
+					closestEdge = linearDepth < cascadeCenter ? cascade.x : cascade.y;
+					margin = 0.25 * pow( closestEdge, 2.0 );
+					csmx = cascade.x - margin / 2.0;
+					csmy = cascade.y + margin / 2.0;
+					if( linearDepth >= csmx && ( linearDepth < csmy || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 ) ) {
 
-				ReflectedLight prevLight = reflectedLight;
-				RE_Direct( directLight, geometry, material, reflectedLight );
+						float dist = min( linearDepth - csmx, csmy - linearDepth );
+						float ratio = clamp( dist / margin, 0.0, 1.0 );
 
-				bool shouldBlend = UNROLLED_LOOP_INDEX != CSM_CASCADES - 1 || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 && linearDepth < cascadeCenter;
-				float blendRatio = shouldBlend ? ratio : 1.0;
+						vec3 prevColor = directLight.color;
+						directionalLightShadow = directionalLightShadows[ i ];
+						directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 
-				reflectedLight.directDiffuse = mix( prevLight.directDiffuse, reflectedLight.directDiffuse, blendRatio );
-				reflectedLight.directSpecular = mix( prevLight.directSpecular, reflectedLight.directSpecular, blendRatio );
-				reflectedLight.indirectDiffuse = mix( prevLight.indirectDiffuse, reflectedLight.indirectDiffuse, blendRatio );
-				reflectedLight.indirectSpecular = mix( prevLight.indirectSpecular, reflectedLight.indirectSpecular, blendRatio );
+						bool shouldFadeLastCascade = UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 && linearDepth > cascadeCenter;
+						directLight.color = mix( prevColor, directLight.color, shouldFadeLastCascade ? ratio : 1.0 );
 
-			}
+						ReflectedLight prevLight = reflectedLight;
+						RE_Direct( directLight, geometry, material, reflectedLight );
+
+						bool shouldBlend = UNROLLED_LOOP_INDEX != CSM_CASCADES - 1 || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 && linearDepth < cascadeCenter;
+						float blendRatio = shouldBlend ? ratio : 1.0;
+
+						reflectedLight.directDiffuse = mix( prevLight.directDiffuse, reflectedLight.directDiffuse, blendRatio );
+						reflectedLight.directSpecular = mix( prevLight.directSpecular, reflectedLight.directSpecular, blendRatio );
+						reflectedLight.indirectDiffuse = mix( prevLight.indirectDiffuse, reflectedLight.indirectDiffuse, blendRatio );
+						reflectedLight.indirectSpecular = mix( prevLight.indirectSpecular, reflectedLight.indirectSpecular, blendRatio );
+
+					}
+
+				#else
+
+					// NOTE: Apply the reminder of directional lights
+
+					directionalLightShadow = directionalLightShadows[ i ];
+					directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+
+					RE_Direct( directLight, geometry, material, reflectedLight );
+
+				#endif
+
 	  	#endif
 
 	}
@@ -135,12 +153,27 @@ IncidentLight directLight;
 			directionalLight = directionalLights[ i ];
 			getDirectionalLightInfo( directionalLight, geometry, directLight );
 
-			#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
+			#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS ) 
 
-			directionalLightShadow = directionalLightShadows[ i ];
-			if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y) directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+				#if ( UNROLLED_LOOP_INDEX < ${csm.cascades} )
 
-			if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && (linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1)) RE_Direct( directLight, geometry, material, reflectedLight );
+					// NOTE: Apply CSM shadows
+
+					directionalLightShadow = directionalLightShadows[ i ];
+					if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y) directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+
+					if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && (linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1)) RE_Direct( directLight, geometry, material, reflectedLight );
+
+				#else
+
+					// NOTE: Apply the reminder of directional lights
+
+					directionalLightShadow = directionalLightShadows[ i ];
+					directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+	
+					RE_Direct( directLight, geometry, material, reflectedLight );
+
+				#endif
 
 			#endif
 
@@ -239,7 +272,7 @@ IncidentLight directLight;
 
 #endif
 `,
-	lights_pars_begin: /* glsl */`
+	lights_pars_begin: (csm: CSM) => /* glsl */`
 #if defined( USE_CSM ) && defined( CSM_CASCADES )
 uniform vec2 CSM_cascades[CSM_CASCADES];
 uniform float cameraNear;


### PR DESCRIPTION
Small bugfixes for 2 long-standing issues:

Solves #13 

Changes:
- Add `lightColor` to CSM constructor
- Add to docs

Solves #10 

Changes:
- Allow usage with other light & shadow sources (limit shader loop to CSM_CASCADES, and loop through the reminder of directional lights normally)
- Instead of appending lights using `Object3D#add`, prepend them to the parent as first light sources on the children's list

![beliarek](https://user-images.githubusercontent.com/9549760/216810488-509dbe20-ef8d-4621-b3e0-e528699ca4df.png)
(left - CSM directional light; right - another directional light; no more WebGL errors thrown on directionalLights loop)
