### PR TITLE
Update shadow.camera.far and near from CSM.lightFar and lightNear

### DIFF
--- a/src/CSM.ts
+++ b/src/CSM.ts
@@ -257,6 +257,8 @@ class CSM {
 			const shadowCam = light.shadow.camera;
 			const texelWidth = ( shadowCam.right - shadowCam.left ) / this.shadowMapSize;
 			const texelHeight = ( shadowCam.top - shadowCam.bottom ) / this.shadowMapSize;
+			shadowCam.far = this.lightFar;
+			shadowCam.near = this.lightNear;
 			light.shadow.camera.updateMatrixWorld( true );
 			_cameraToLightMatrix.multiplyMatrices( light.shadow.camera.matrixWorldInverse, camera.matrixWorld );
 			frustums[ i ].toSpace( _cameraToLightMatrix, _lightSpaceFrustum );


### PR DESCRIPTION
If I do not do any mistake, I think it was the initially purpose of lightFar and lightNear properties. But they aren't updated when the value changes. So to avoid hard update like for each lights do csm.light.shadow.camera.far = csm.lightFar it would be nice to already have it in csm.update.